### PR TITLE
Add support for regular mime types

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,8 @@ types {
     text/csv csv;
 }
 
+include             /etc/nginx/mime.types;
+
 #upstream discourse {
 #  server unix:/opt/app-root/src/discourse/tmp/sockets/nginx.http.sock;
 #  server unix:/opt/app-root/src/discourse/tmp/sockets/nginx.https.sock;


### PR DESCRIPTION
Our test instance show warnings and the console show:
```
The script from “https://discourse.example.org/assets/start-discourse-efa4e5abfbd1b50b5152ffbe64d5dcea9f7c33f766dcc6387e2711f0f2112148.js” was loaded even though its MIME type (“text/plain”) is not a valid JavaScript MIME type.
```