### PR TITLE
Add headers to not overload discourse with requests

### DIFF
--- a/openshift/discourse.yml
+++ b/openshift/discourse.yml
@@ -252,6 +252,9 @@ objects:
             httpGet:
               path: /
               port: 8080
+              httpHeaders:
+              - name: Discourse-Track-View
+                value: '0'
             initialDelaySeconds: 30
             timeoutSeconds: 3
           ports:
@@ -260,6 +263,9 @@ objects:
             httpGet:
               path: /
               port: 8080
+              httpHeaders:
+              - name: Discourse-Track-View
+                value: '0'
             initialDelaySeconds: 3
             timeoutSeconds: 3
           volumeMounts:


### PR DESCRIPTION
Users from pulp reported periodic failure, and upon searching
I started to notice a high level of crawler requests and near constant.
Upon reducing the number of liveness probe, this solved the problem.

Adding a header to not log those attempt should also help discourse